### PR TITLE
feat: handle arbitrary attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ npm install geom-builder
 
 ```js
 import createGeomBuilder from "geom-builder";
-const builder = createGeomBuilder({ colors: 4, cells: 3 });
+const builder = createGeomBuilder({ vertexColors: 4, cells: 3 });
 
 builder.addPosition([0, 0, 0]);
 builder.addPosition([1, 0, 0]);
 builder.addPosition([1, 1, 0]);
 
-builder.addColor([1, 0, 0, 1]);
-builder.addColor([0, 1, 0, 1]);
-builder.addColor([0, 0, 1, 1]);
+builder.addVertexColor([1, 0, 0, 1]);
+builder.addVertexColor([0, 1, 0, 1]);
+builder.addVertexColor([0, 0, 1, 1]);
 
 builder.addCell([0, 1, 0]);
 // or builder.addCell(0, 1, 0)
@@ -34,35 +34,35 @@ builder.addCell([0, 1, 0]);
 //builder.cells = Uint16Array(0, 1, 2, ...)
 ```
 
-# API
+## API
 
-## GeomBuilder
+### `createGeomBuilder(opts): geometryBuilder`
 
-```js
-var createGeomBuilder = require("geom-builder");
-```
+**Parameters**
 
-### `builder = createGeomBuilder(opts)`
-
-Create new geometry builder. Each attribute can be enabledby passing an integer number e.g.: `createGeomBuilder({ positions: 3, colors: 4, cells: 2 })` for colored lines.
-
-- `opts`
-  - `size` : Int - preallocated vertex buffer size, `32`
-  - `positions` : Int - enable positions attribute, `3`
-  - `colors` : Int - enable colors attribute
-  - `normals` : Int - enable normals attribute
-  - `uvs` : Int - enable uvs attribute
-  - `cells` : Int - enable cells (indices)
+- opts
+  - size: `Int` (default: `32`) - preallocated vertex buffer size
+  - positions: `Int` (default: `3`) - positions attribute
+  - normals: `Int` - enable normals attribute
+  - uvs: `Int` - enable uvs attribute
+  - vertexColors: `Int` - enable vertexColors attribute
+  - cells: `Int` - enable cells (indices)
+  - attributeNames: `Int` - enable an arbitrary attribute
 
 _Note: `positions` attribute is always enabled and defaults to size 3_
+_Note: attribute names should be plural_
+
+**Returns**
+
+geometryBuilder: `{ positions: Float32Array, vertexColors: Float32Array, cells: Uint32Array }`: each attribute can be enabled by passing an integer e.g.: `createGeomBuilder({ positions: 3, vertexColors: 4, cells: 2 })`.
 
 ## Adding vertex and index data
 
-Every time we add vertex position, color etc internal buffer size is checked and expanded by doubling its capacity as necessary. Therefore `builder.count` should be used to determine how many vertices to draw instead of `builder.positions.length` as not all allocated vertex has to be used. Similarly for meshes with cells `builder.indexCount` should be used instead of `builder.cells.length`.
+Every time we add vertex position, color, etc., the internal buffer size is checked and expanded by doubling its capacity as necessary. Therefore `builder.count` should be used to determine how many vertices to draw instead of `builder.positions.length` as not all allocated vertices have to be used. Similarly for meshes with cells `builder.cellsIndex` should be used instead of `builder.cells.length`.
 
-All enabled attributes can be accessed by `builder.attribName` e.g.: `builder.colors`.
+All enabled attributes can be accessed by `builder.attributeName` e.g. `builder.vertexColors`.
 
-All data methods accept structs or individual components. E.g. `builder.addPosition(v)` and `builder.addPosition(v[0], v[1], v[2])`.
+All data methods accept structs or individual components e.g. `builder.addPosition(v)` or `builder.addPosition(v[0], v[1], v[2])`.
 
 ### builder.reset()
 
@@ -70,33 +70,39 @@ Reset all the counters to prepare arrays for reuse. Nothing is deallocated.
 
 ### builder.addPosition(pos)
 
-- `pos` : vec3 - position to add
+- pos: `vec3` - position to add
 
-_Note: adding a vertex position will increment `builder.count` counter indicanting number of vertices added so far_
-
-### builder.addColor(color)
-
-- `color` : vec4 - color to add
-
-_Note: you need to enable colors in constructor_
+_Note: adding a vertex position will increment `builder.count` counter indicating number of vertices added so far_
 
 ### builder.addNormal(normal)
 
-- `normal` : vec3 - normal to add
+- normal: `vec3` - normal to add
 
 _Note: you need to enable normals in constructor_
 
 ### builder.addUV(uv)
 
-- `uv` : vec2 - uv texture coord to add
+- uv: `vec2` - uv texture coord to add
 
 _Note: you need to enable uvs in constructor_
 
+### builder.addVertexColor(color)
+
+- vertexColor: `vec4` - vertexColor to add
+
+_Note: you need to enable vertexColors in constructor_
+
 ### builder.addCell(cell)
 
-- `cell` : number, vec2, vec3 - cell (face) with vertex indices to add
+- cell: `number | vec2 | vec3` - cell (face) with vertex indices to add
 
 _Note: you need to enable cells in constructor_
+
+### builder.addAttributeName(attributeValue)
+
+- attributeValue: `number | array` - any attribute to add
+
+_Note: you need to enable attributeNames (plural) in constructor to get builder.addAttributeName (singular)_
 
 ## License
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,7 +2,7 @@ import createGeomBuilder from "../index.js";
 
 import createContext from "pex-context";
 import random from "pex-random";
-import { create, fromHSLuv, toRGB } from "pex-color";
+import { create, fromHSLuv } from "pex-color";
 import { perspective as createCamera, orbiter as createOrbiter } from "pex-cam";
 
 const ctx = createContext({
@@ -28,7 +28,7 @@ const clearCmd = {
 const N = 280;
 
 const HsluvToRgb = ([h, s, l]) =>
-  toRGB(fromHSLuv(create(), (h % 360) / 360, (s % 100) / 100, (l % 100) / 100));
+  fromHSLuv(create(), (h % 360) / 360, (s % 100) / 100, (l % 100) / 100);
 
 function noiseFunc(x, y, z) {
   var n = 0;
@@ -70,7 +70,7 @@ function createGeometryFromArrays() {
   }
   return {
     positions: positions,
-    colors: colors,
+    vertexColors: colors,
     count: positions.length,
   };
 }
@@ -106,7 +106,7 @@ function createGeometryFromTypedArrays() {
   }
   return {
     positions: positions,
-    colors: colors,
+    vertexColors: colors,
     count: N * N * 6,
   };
 }
@@ -184,14 +184,14 @@ function createGeometryFromTypedArraysNoGC() {
   }
   return {
     positions: positions,
-    colors: colors,
+    vertexColors: colors,
     count: N * N * 6,
   };
 }
 
 function createGeometryFromGeomBuilder(builder) {
   random.seed(0);
-  builder = builder || createGeomBuilder({ colors: true });
+  builder = builder || createGeomBuilder({ vertexColors: true });
   for (let x = 0; x < N; x++) {
     for (let z = 0; z < N; z++) {
       const a = [x / N - 0.5, 0, z / N - 0.5];
@@ -215,12 +215,12 @@ function createGeometryFromGeomBuilder(builder) {
       builder.addPosition(d);
       builder.addPosition(c);
 
-      builder.addColor(color);
-      builder.addColor(color);
-      builder.addColor(color);
-      builder.addColor(color);
-      builder.addColor(color);
-      builder.addColor(color);
+      builder.addVertexColor(color);
+      builder.addVertexColor(color);
+      builder.addVertexColor(color);
+      builder.addVertexColor(color);
+      builder.addVertexColor(color);
+      builder.addVertexColor(color);
     }
   }
   return builder;
@@ -228,7 +228,7 @@ function createGeometryFromGeomBuilder(builder) {
 
 function createGeometryFromGeomBuilderWithCells(builder, solidColor, yOffset) {
   random.seed(0);
-  builder = builder || createGeomBuilder({ colors: true, cells: true });
+  builder = builder || createGeomBuilder({ vertexColors: true, cells: true });
   var index = 0;
   for (let x = 0; x < N; x++) {
     for (let z = 0; z < N; z++) {
@@ -245,7 +245,7 @@ function createGeometryFromGeomBuilderWithCells(builder, solidColor, yOffset) {
         HsluvToRgb([80 + 80 * (a[1] * 4), 60, 60 + 30 * (1 - a[1] * 4)]);
 
       builder.addPosition(a);
-      builder.addColor(color);
+      builder.addVertexColor(color);
       if (x < N - 1 && z < N - 1) {
         builder.addCell([index, index + 1, index + 1 + N]);
         builder.addCell([index, index + 1 + N, index + N]);
@@ -258,7 +258,7 @@ function createGeometryFromGeomBuilderWithCells(builder, solidColor, yOffset) {
 
 function createGeometryFromGeomBuilderWithCellsAsLines(builder) {
   random.seed(0);
-  builder = builder || createGeomBuilder({ colors: true, cells: true });
+  builder = builder || createGeomBuilder({ vertexColors: true, cells: true });
   var index = 0;
   for (let x = 0; x < N; x++) {
     for (let z = 0; z < N; z++) {
@@ -273,7 +273,7 @@ function createGeometryFromGeomBuilderWithCellsAsLines(builder) {
       const color = HsluvToRgb([180 + 80, 60, 60]);
 
       builder.addPosition(a);
-      builder.addColor(color);
+      builder.addVertexColor(color);
       if (x < N - 1 && z < N - 1) {
         if (x % 3 === 0) {
           builder.addCell([index, index + 1]);
@@ -287,7 +287,7 @@ function createGeometryFromGeomBuilderWithCellsAsLines(builder) {
 
 function createGeometryFromGeomBuilderWithCellsAsColumns(builder) {
   random.seed(0);
-  builder = builder || createGeomBuilder({ colors: true, cells: true });
+  builder = builder || createGeomBuilder({ vertexColors: true, cells: true });
   var index = 0;
   var N2 = N / 4;
   for (let x = 0; x < N2; x++) {
@@ -297,7 +297,7 @@ function createGeometryFromGeomBuilderWithCellsAsColumns(builder) {
       let color = [0, 0, 0, 1];
 
       builder.addPosition(a);
-      builder.addColor(color);
+      builder.addVertexColor(color);
       if (x < N2 - 1 && z < N2 - 1) {
         builder.addCell([index, index + 1]);
         builder.addCell([index, index + N2]);
@@ -310,7 +310,7 @@ function createGeometryFromGeomBuilderWithCellsAsColumns(builder) {
 
 function createGeometryFromGeomBuilderWithCellsAsPoints(builder) {
   random.seed(0);
-  builder = builder || createGeomBuilder({ colors: true, cells: true });
+  builder = builder || createGeomBuilder({ vertexColors: true, cells: true });
   var index = 0;
   for (let x = 0; x < N; x++) {
     for (let z = 0; z < N; z++) {
@@ -325,7 +325,7 @@ function createGeometryFromGeomBuilderWithCellsAsPoints(builder) {
       const color = HsluvToRgb([180 + 80, 60, 60]);
 
       builder.addPosition(a);
-      builder.addColor(color);
+      builder.addVertexColor(color);
       if (x < N - 1 && z < N - 1) {
         if (x % 4 === 0 && z % 4 === 0) {
           builder.addCell([index]);
@@ -339,7 +339,7 @@ function createGeometryFromGeomBuilderWithCellsAsPoints(builder) {
 
 const vert = /* glsl */ `
 attribute vec3 aPosition;
-attribute vec4 aColor;
+attribute vec4 aVertexColor;
 
 uniform mat4 uProjectionMatrix;
 uniform mat4 uViewMatrix;
@@ -347,7 +347,7 @@ uniform mat4 uViewMatrix;
 varying vec4 vColor;
 
 void main () {
-  vColor = aColor;
+  vColor = aVertexColor;
   gl_Position = uProjectionMatrix * uViewMatrix * vec4(aPosition, 1.0);
   gl_PointSize = 5.0;
 }
@@ -412,7 +412,7 @@ console.time("geometry from arrays - upload");
 const landscape1 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g1.positions),
-    aColor: ctx.vertexBuffer(g1.colors),
+    aVertexColor: ctx.vertexBuffer(g1.vertexColors),
   },
   count: g1.count,
 };
@@ -426,7 +426,7 @@ console.time("geometry from typed arrays - upload");
 const landscape2 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g2.positions),
-    aColor: ctx.vertexBuffer(g2.colors),
+    aVertexColor: ctx.vertexBuffer(g2.vertexColors),
   },
   count: g2.count,
 };
@@ -439,7 +439,7 @@ console.time("geometry from typed arrays no GC - upload");
 const landscape3 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g3.positions),
-    aColor: ctx.vertexBuffer(g3.colors),
+    aVertexColor: ctx.vertexBuffer(g3.vertexColors),
   },
   count: g3.count,
 };
@@ -457,7 +457,7 @@ console.time("geometry from geom builder - upload cold");
 const landscape4 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g4.positions),
-    aColor: ctx.vertexBuffer(g4.colors),
+    aVertexColor: ctx.vertexBuffer(g4.vertexColors),
   },
   count: g4.count,
 };
@@ -465,7 +465,7 @@ console.timeEnd("geometry from geom builder - upload cold");
 
 console.time("geometry from geom builder - upload hot");
 ctx.update(landscape4.attributes.aPosition, { data: g4.positions });
-ctx.update(landscape4.attributes.aColor, { data: g4.colors });
+ctx.update(landscape4.attributes.aVertexColor, { data: g4.vertexColors });
 console.timeEnd("geometry from geom builder - upload hot");
 
 console.time("geometry from geom builder with indices - build cold");
@@ -481,7 +481,7 @@ console.time("geometry from geom builder with indices - upload cold");
 const landscape5 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g5.positions),
-    aColor: ctx.vertexBuffer(g5.colors),
+    aVertexColor: ctx.vertexBuffer(g5.vertexColors),
   },
   indices: { buffer: ctx.indexBuffer(g5.cells), count: g5.indexCount },
 };
@@ -489,7 +489,7 @@ console.timeEnd("geometry from geom builder with indices - upload cold");
 
 console.time("geometry from geom builder with indices - upload hot");
 ctx.update(landscape5.attributes.aPosition, { data: g5.positions });
-ctx.update(landscape5.attributes.aColor, { data: g5.colors });
+ctx.update(landscape5.attributes.aVertexColor, { data: g5.vertexColors });
 console.timeEnd("geometry from geom builder with indices - upload hot");
 
 console.log("geometry indices allocated", g5.cells.length);
@@ -499,7 +499,7 @@ const g6bg = createGeometryFromGeomBuilderWithCells(null, clearColor, -0.01);
 const landscape6bg = {
   attributes: {
     aPosition: ctx.vertexBuffer(g6bg.positions),
-    aColor: ctx.vertexBuffer(g6bg.colors),
+    aVertexColor: ctx.vertexBuffer(g6bg.vertexColors),
   },
   indices: ctx.indexBuffer(g6bg.cells),
 };
@@ -508,7 +508,7 @@ const g6 = createGeometryFromGeomBuilderWithCellsAsLines();
 const landscape6 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g6.positions),
-    aColor: ctx.vertexBuffer(g6.colors),
+    aVertexColor: ctx.vertexBuffer(g6.vertexColors),
   },
   indices: ctx.indexBuffer(g6.cells),
 };
@@ -517,7 +517,7 @@ const g6p = createGeometryFromGeomBuilderWithCellsAsPoints();
 const landscape6p = {
   attributes: {
     aPosition: ctx.vertexBuffer(g6p.positions),
-    aColor: ctx.vertexBuffer(g6p.colors),
+    aVertexColor: ctx.vertexBuffer(g6p.vertexColors),
   },
   indices: ctx.indexBuffer(g6p.cells),
 };
@@ -526,7 +526,7 @@ const g7 = createGeometryFromGeomBuilderWithCellsAsColumns();
 const landscape7 = {
   attributes: {
     aPosition: ctx.vertexBuffer(g7.positions),
-    aColor: ctx.vertexBuffer(g7.colors),
+    aVertexColor: ctx.vertexBuffer(g7.vertexColors),
   },
   indices: ctx.indexBuffer(g7.cells),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "typed-array-constructor": "^1.0.1"
+        "typed-array-constructor": "^1.0.2"
       },
       "devDependencies": {
-        "es-module-shims": "^1.8.2",
-        "pex-cam": "^3.0.0-alpha.1",
-        "pex-color": "^2.0.0-alpha.2",
-        "pex-context": "^3.0.0-alpha.8",
-        "pex-random": "^2.0.0-alpha.2"
+        "es-module-shims": "^2.6.2",
+        "pex-cam": "^3.0.1",
+        "pex-color": "^2.3.0",
+        "pex-context": "^4.0.0",
+        "pex-random": "^2.1.2"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -24,10 +24,11 @@
       }
     },
     "node_modules/es-module-shims": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.2.tgz",
-      "integrity": "sha512-7vIYVzpOhXtpc3Yn03itB+GSgVZFW7oL4kdydA+iL+IEi7HiSLBUxM05QFw4SxTl6e++pMpGqZPo2+vdNs3TbA==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.6.2.tgz",
+      "integrity": "sha512-50HiheXiMg28GQagXXYMqzUuVPKsAhFLuWIxBxDbfnmT+hFTU8AyfAJaWjDaWmQbjNiPwTuuPqq7NAKFRdLaow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/interpolate-angle": {
       "version": "1.0.2",
@@ -57,91 +58,105 @@
       "dev": true
     },
     "node_modules/pex-cam": {
-      "version": "3.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/pex-cam/-/pex-cam-3.0.0-alpha.1.tgz",
-      "integrity": "sha512-mVDMzz5cyGA2em7k/fq9Yq9inO1hRputz4poeiXKdzydUh+EHXVvx3gzNyeXez2BTfV0TLpuoCgoLYLc5b4Ifw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pex-cam/-/pex-cam-3.0.1.tgz",
+      "integrity": "sha512-TU/WtVhU8j0gc2Ip3D73vad+RallX5jVh3DhgTWcFqAU6RLA8pIgI9k64dwQwSzyE25H9dqigi0oBdFyzU74Kw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "interpolate-angle": "^1.0.2",
         "latlon-to-xyz": "^1.0.1",
         "mouse-event-offset": "^3.0.2",
-        "pex-geom": "^3.0.0-alpha.0",
-        "pex-math": "^4.0.0-alpha.1",
+        "pex-geom": "^3.1.0",
+        "pex-math": "^4.1.2",
         "xyz-to-latlon": "^1.0.2"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.5.x"
       }
     },
     "node_modules/pex-color": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/pex-color/-/pex-color-2.0.0-alpha.2.tgz",
-      "integrity": "sha512-xG7851UGruaVOyf7yFeJu1BFmIGLUYr4B32XXCVw6mCVTdsrmuihz6L80+ryJiHqc4DGWNRNN9KTa8nU0J3fgw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pex-color/-/pex-color-2.3.0.tgz",
+      "integrity": "sha512-Ud/SRjL+6c5cydWM5Lw7N/VIDPDDTBOLwRjY9Zaj2U82/lHNw4uqRG+MMhOWna0ObrLIBg0Kv37mxolg73LXqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.2.x"
       }
     },
     "node_modules/pex-context": {
-      "version": "3.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/pex-context/-/pex-context-3.0.0-alpha.8.tgz",
-      "integrity": "sha512-8ub8SX0mskdcsnvV2Hz1FGTvLyIto4UY20re/taGMdfalt/obqa/qeVNLF2F8WshBOaDdHOmSFtMYdrHuDfC9Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pex-context/-/pex-context-4.0.0.tgz",
+      "integrity": "sha512-gP9TdzknKDywDBL1lhGnd/Fct1oZ9VvwRbDaE63IILPjsR5jCuYC4pjiiDHmQY0AOBzJmhu7SrACB1EdjJIrkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "pex-gl": "^3.0.0-alpha.0"
+        "pex-gl": "^3.0.2"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.5.x"
       }
     },
     "node_modules/pex-geom": {
-      "version": "3.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.0.0-alpha.4.tgz",
-      "integrity": "sha512-eqfP69aNwF7HURLb85P7jZf1S23oo5Hf6pW9bUKnEASaCAEyAlH/EmJSc925Yc58Ax3yv12+wAAoFBqFov8znA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.1.0.tgz",
+      "integrity": "sha512-s17p6aLAJymGlt93aOy1tLk2uHLymfYO715EYXqgfJvgyr58aw+QQrzK5bBofz7i5h5jG286aobsKtRyS/0iiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "pex-math": "^4.0.0-alpha.2"
+        "pex-math": "^4.1.1"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.2.x"
       }
     },
     "node_modules/pex-gl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pex-gl/-/pex-gl-3.0.1.tgz",
-      "integrity": "sha512-RSbWPhWSjBLc+9tkfMeTR+G9rg9ESXHRyK7t2Qa3Nuupo4SDPiVw0RuZkgDfTpu4RiDZV6nBdGof7J/XIqTP2Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pex-gl/-/pex-gl-3.0.2.tgz",
+      "integrity": "sha512-q0MEUXyRlXEa7A/QGQn7GvrkLf+Yc+tRpTRFW0gmbG1RnJpKC0U504WYaB9O47OoMmy9LlKGCaolP2cJJUw5gQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.6.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.2.x"
       }
     },
     "node_modules/pex-math": {
-      "version": "4.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.0.0-alpha.5.tgz",
-      "integrity": "sha512-MXh6dVrl0CHvHvgFujrcPbkgmjUi4Y+UCPEGlKds7Eo0P0C+p2uLqG+5oPrOrq6Lph3RSoEv9M8ZNNBP046iJA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.1.2.tgz",
+      "integrity": "sha512-F7tB+weV/rhg2o9B4DCvuUTZHMkicmorusvhmRf1IjveHXFZyYTY/9/S+dpkhnEVeAZ5KNyjCK7bCsKEbYXoXQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.5.x"
       }
     },
     "node_modules/pex-random": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/pex-random/-/pex-random-2.0.0-alpha.2.tgz",
-      "integrity": "sha512-URXejVMr//b7aSqzN+dbqpu5Ib0tpYGfI9Oih4/StUnuQvCxx3Jfr+LJby0DzMsruuIP+F1nPDoBmhwBl9mPDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pex-random/-/pex-random-2.1.2.tgz",
+      "integrity": "sha512-CgtNKg5zWMggm3EB1YkrEof0y42Bo5CTXlTxn9nXKvy10WhfnYo0920YwOkh2psG7qpigwj40q0+EuPdluRAnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "seedrandom": "^3.0.5",
-        "simplex-noise": "4.0.1"
+        "simplex-noise": "^4.0.3"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.6.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.2.x"
       }
     },
     "node_modules/seedrandom": {
@@ -151,15 +166,16 @@
       "dev": true
     },
     "node_modules/simplex-noise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.1.tgz",
-      "integrity": "sha512-zl/+bdSqW7HJOQ0oDbxrNYaF4F5ik0i7M6YOYmEoIJNtg16NpvWaTTM1Y7oV/7T0jFljawLgYPS81Uu2rsfo1A==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typed-array-constructor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-constructor/-/typed-array-constructor-1.0.1.tgz",
-      "integrity": "sha512-u0C7NyHOh4nPdFy5BsjEQuDXsuCg8PvinJ7b35IXdQ/dcOrwavzMh3YYo0Gj2Oq+69nNDOlxwKcVAV++x+m/8A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-constructor/-/typed-array-constructor-1.0.2.tgz",
+      "integrity": "sha512-HeBkIJlZRU3d4DNCZ7QRGAPvTFxSgl8qYfbGvQy9S9/w3yMl74fewmQ9Uz4nQWtxd0TN62QikEm+pNZAU7yOwg==",
       "funding": [
         {
           "type": "individual",
@@ -170,9 +186,11 @@
           "url": "https://commerce.coinbase.com/checkout/56cbdf28-e323-48d8-9c98-7019e72c97f3"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1",
+        "snowdev": ">=2.2.x"
       }
     },
     "node_modules/xyz-to-latlon": {

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
     "release": "snowdev release"
   },
   "dependencies": {
-    "typed-array-constructor": "^1.0.1"
+    "typed-array-constructor": "^1.0.2"
   },
   "devDependencies": {
-    "es-module-shims": "^1.8.2",
-    "pex-cam": "^3.0.0-alpha.1",
-    "pex-color": "^2.0.0-alpha.2",
-    "pex-context": "^3.0.0-alpha.8",
-    "pex-random": "^2.0.0-alpha.2"
+    "es-module-shims": "^2.6.2",
+    "pex-cam": "^3.0.1",
+    "pex-color": "^2.3.0",
+    "pex-context": "^4.0.0",
+    "pex-random": "^2.1.2"
   },
   "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=9.6.4"
+    "node": ">=22.0.0",
+    "npm": ">=10.5.1",
+    "snowdev": ">=2.5.x"
   }
 }


### PR DESCRIPTION
- allows passing `createGeomBuilder({ vertexColors: 4, treeIds: 1 })`
- match pex-renderer
- around 33% smaller